### PR TITLE
Add scapval zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # contest-data
+
+Links to data available in repository:
+
+- [SCAP Content Validation Tool](data/scapval-1.3.6-rc3.zip)


### PR DESCRIPTION
SCAPval for nist-validation test in Contest - https://github.com/RHSecurityCompliance/contest/pull/207

The zip comes from https://csrc.nist.gov/Projects/Security-Content-Automation-Protocol/SCAP-Releases/SCAP-1-3

```
$ sha256sum scapval-1.3.6-rc3.zip 
82e60cbd184a6df1744ba819e4aaa5f8857d223dc11c1ac7e72f4e99895a2b32  scapval-1.3.6-rc3.zip
```